### PR TITLE
Added support for windows, just had to add extension handling

### DIFF
--- a/tasks/chimp.js
+++ b/tasks/chimp.js
@@ -20,8 +20,12 @@ module.exports = function(grunt) {
     // Make this task async
     var done = this.async();
     var options = this.options();
+    var chimpExecutable = '/node_modules/.bin/chimp';
+    if (process.platform === 'win32') {
+        chimpExecutable += '.cmd';
+    }
 
-    var chimpBin = path.resolve(process.cwd() + '/node_modules/.bin/chimp');
+    var chimpBin = path.resolve(process.cwd() + chimpExecutable);
     var args = [];
 
     for (var option in options) {


### PR DESCRIPTION
Cuke tests pass. This bug was found on windows 10. I have attached the passing tests below; I recommend you run on a non-windows box before merge, but it should be fine.

![win32](https://cloud.githubusercontent.com/assets/3287572/26687207/30cd2374-46bd-11e7-8a72-d89017b9dc4d.png)
