### PR TITLE
Array support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,7 +33,12 @@ module.exports = function(grunt) {
       cucumber: {
         options: {
           path: 'example/features',
-          browser: 'firefox'
+          browser: 'firefox',
+          // Reference: https://github.com/cucumber/cucumber/wiki/Tags
+          // JSON.stringify b/c the chimp module recieves formatted strings
+          // so by default we get "@iShouldrunSuccesfully,@orIshouldRunSuccesfully,@becauseIAmHere,~@iWontRun"
+          // which chains together as a string and runs all of the below as an OR conditional
+          tags: JSON.stringify(['@iShouldRunSuccesfully,@orIShouldRunSuccesfully', '@becauseIAmHere', '~@iWontRun'])
         }
       },
       mocha: {

--- a/example/features/example.feature
+++ b/example/features/example.feature
@@ -3,7 +3,31 @@ Feature: Google for Cucumber
   As a BDDer
   I want to find Cucumber resources on Google
 
+  @iShouldRunSuccesfully @becauseIAmHere
   Scenario: find xolv.io
     Given I am on Google
     When I search for "Chimp BDD"
     Then I see a link to "http://xolv.io/"
+
+  #
+  # The Below tests exist to show off the tags support
+  # to check conditional look @ GruntFile.js, config->tags
+  #
+
+  @orIShouldRunSuccesfully @becauseIAmHere
+  Scenario: Test Conditional Cucumber Tagging -- SHOULD RUN
+    Given I am on Google
+
+  #below should not run because it does not have "@iShouldRunSuccesfully" or "@orIShouldRunSuccesfully"
+  @becauseIAmHere
+  Scenario: Test Conditional Cucumber Tagging -- SHOULD NOT RUN
+    Given I am on Google
+
+  @iWontrun
+  Scenario: Just a dead scenario -- SHOULD NOT RUN
+    Given I am on Google
+
+  # This should not run b/c it meets only the ~@iWontRun conditional
+  Scenario: Just another dead scenario -- SHOULD NOT RUN
+    Given I am on Google
+

--- a/tasks/chimp.js
+++ b/tasks/chimp.js
@@ -13,6 +13,20 @@ module.exports = function(grunt) {
   var path = require('path');
   var spawn = require('child_process').spawn;
 
+  /**
+   * Simple check to see if the input is a json type
+   * @param str
+   * @returns {boolean}
+   */
+  var isJSON = function isJson(str) {
+    try {
+      JSON.parse(str);
+    } catch (e) {
+      return false;
+    }
+    return true;
+  };
+
   // Please see the Grunt documentation for more information regarding task
   // creation: http://gruntjs.com/creating-tasks
 
@@ -29,7 +43,21 @@ module.exports = function(grunt) {
     var args = [];
 
     for (var option in options) {
-      args.push('--' + option + '=' + options[option]);
+      if (isJSON(options[option])) {
+        var parsedOptions = JSON.parse(options[option]);
+        // If the option that was passed in was an array, we want to treat each argument seperately
+        // eg, for tags we want --tags=@tagname --tags=@tagname2; not: --tags=@tagname,@tagname2
+        // (cucumber cares -- https://github.com/cucumber/cucumber/wiki/Tags )
+        if(Array.isArray(parsedOptions)) {
+          parsedOptions.forEach((parsedOption) => args.push('--' + option + '=' + parsedOption));
+        }
+        else {
+          args.push('--' + option + '=' + options[option]);
+        }
+      }
+      else {
+        args.push('--' + option + '=' + options[option]);
+      }
     }
 
     var chimp = spawn(chimpBin, args);

--- a/tasks/chimp.js
+++ b/tasks/chimp.js
@@ -20,8 +20,12 @@ module.exports = function(grunt) {
     // Make this task async
     var done = this.async();
     var options = this.options();
+    var chimpExecutable = '/node_modules/.bin/chimp';
+    if (process.platform === 'win32') {
+        chimpExecutable += '.cmd';
+    }
 
-    var chimpBin = path.resolve(process.cwd() + '/node_modules/.bin/chimp');
+    var chimpBin = path.resolve(process.cwd() + chimpExecutable);
     var args = [];
 
     for (var option in options) {


### PR DESCRIPTION
So this was a little convoluted, and I think this is an appropriate fix. 

Essentially the issue is primarily with the way this module is calling the chimp executable. According to the documentation located [here](https://github.com/cucumber/cucumber/wiki/Tags) tags need to be passed in 2 ways. If we want to AND tags together, we need to have
`--tag=@tagname --tag=@tagname2` where as if we want to OR: `--tag=@tagname,@tagname2`

This chimp module grabs the pre-formatted arguments. So if we pass it an array, the translation is the following: `tags: ['@tag1', '@tag2'] ~> '@tag1,@tag2'` which isn't want we want all the time. So this fix allows you to pass an array of tags to support so if you want @tag1 AND @tag2 OR @tag3 we would pass: `tags: JSON.stringify(['@tag1', '@tag2,@tag3'])`

This does not break any functional code, so if people pass in `tags: '@tag1,tag2'` it will work fine.

I have changed your test grunt file to accomidate and demonstrate these changes, i recommend you start the code review there.
![image](https://user-images.githubusercontent.com/3287572/27592010-6af5e036-5b21-11e7-96bb-3c8d7d060453.png)

